### PR TITLE
'which env' gets '/usr/bin/env' as path

### DIFF
--- a/EZPWC.pl
+++ b/EZPWC.pl
@@ -1,4 +1,4 @@
-#!/usr/env perl
+#!/usr/bin/env perl
 # Eazy Perl Weekly Challenge EZPWC  
 # This is a script that attempts to make Perl Weekly Challenges submission
 # throgh github easier to do.  forks, clones, fetches, create new branch,


### PR DESCRIPTION
I stumbled over "/usr/env perl", since I only ever came across "/usr/bin/env" as path.
But maybe I've missed something?